### PR TITLE
RelatedTiers -> TierGroup

### DIFF
--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -7,7 +7,7 @@ from praatio.data_classes.interval_tier import IntervalTier
 from praatio.data_classes.textgrid import Textgrid
 from praatio.textgrid import openTextgrid
 from aligned_textgrid.sequences.sequences import SequenceInterval, Top, Bottom
-from aligned_textgrid.sequences.tiers import SequenceTier, RelatedTiers
+from aligned_textgrid.sequences.tiers import SequenceTier, TierGroup
 from typing import Type, Sequence, Literal
 import numpy as np
 import warnings
@@ -34,8 +34,8 @@ class AlignedTextGrid:
     Attributes:
         entry_classes (list[Sequence[Type[SequenceInterval]]]): 
             The entry classes for each tier within a tier group.
-        tier_groups (list[RelatedTiers]):
-            a list of `RelatedTiers`
+        tier_groups (list[TierGroup]):
+            a list of `TierGroup`
         xmax (float):
             Maximum time
         xmin (float):
@@ -141,14 +141,14 @@ class AlignedTextGrid:
         nested IntervalTier and entry class
 
         Returns:
-            (list[RelatedTiers]): _description_
+            (list[TierGroup]): _description_
         """
         tier_groups = []
         for tier_group, classes in zip(self.tg_tiers, self.entry_classes):
             tier_list = []
             for tier, entry_class in zip(tier_group, classes):
                 tier_list.append(SequenceTier(tier, entry_class))
-            tier_groups.append(RelatedTiers(tier_list))
+            tier_groups.append(TierGroup(tier_list))
         return tier_groups
     
     @property

--- a/src/aligned_textgrid/sequences/tiers.py
+++ b/src/aligned_textgrid/sequences/tiers.py
@@ -211,7 +211,7 @@ class SequenceTier:
         out_tg.save(save_path, "long_textgrid")
 
 
-class RelatedTiers:
+class TierGroup:
     """_Relates tiers_
 
     Args:
@@ -293,7 +293,7 @@ class RelatedTiers:
     def __repr__(self):
         n_tiers = len(self.tier_list)
         classes = [x.__name__ for x in self.entry_classes]
-        return f"RelatedTiers with {n_tiers} tiers. {repr(classes)}"
+        return f"TierGroup with {n_tiers} tiers. {repr(classes)}"
     
     def _arrange_tiers(
             self, 

--- a/tests/test_sequences/test_sequences.py
+++ b/tests/test_sequences/test_sequences.py
@@ -581,7 +581,7 @@ class TestFusion:
         ],
         entry_class=self.Lower)
 
-        rt = RelatedTiers(tiers=[tier1, tier2])
+        rt = TierGroup(tiers=[tier1, tier2])
         assert len(rt[0]) == 2
         assert len(rt[1]) == 4
 
@@ -630,7 +630,7 @@ class TestFusion:
         ],
         entry_class=self.Lower)
 
-        rt = RelatedTiers(tiers=[tier1, tier2])
+        rt = TierGroup(tiers=[tier1, tier2])
         assert len(rt[0]) == 2
         assert len(rt[1]) == 4
 

--- a/tests/test_tiers/test_SequenceTier.py
+++ b/tests/test_tiers/test_SequenceTier.py
@@ -256,8 +256,8 @@ class TestTierPop:
         assert len(self.tier) == 2
         assert a.fol is c
 
-class TestRelatedTiersDefault:
-    rt = RelatedTiers()
+class TestTierGroupDefault:
+    rt = TierGroup()
     
     def test_ranges(self):
         assert self.rt.xmin is None
@@ -286,8 +286,8 @@ class TestReadTiers:
     tg_phone = SequenceTier(read_tg.tiers[1], entry_class=MyPhone)
 
     def test_relation(self):
-        rt = RelatedTiers([self.tg_word, self.tg_phone])
-        rt2 = RelatedTiers([self.tg_phone, self.tg_word])
+        rt = TierGroup([self.tg_word, self.tg_phone])
+        rt2 = TierGroup([self.tg_phone, self.tg_word])
 
         assert rt.entry_classes == rt2.entry_classes
         assert all([type(x) is self.MyWord for x in rt.tier_list[0]])
@@ -300,19 +300,19 @@ class TestReadTiers:
         assert all([not x.super_instance is None for x in rt[1]])
     
     def test_in_get_len(self):
-        rt = RelatedTiers([self.tg_word, self.tg_phone])
+        rt = TierGroup([self.tg_word, self.tg_phone])
 
         assert self.tg_phone in rt
         assert rt[0] is self.tg_word
         assert len(rt) == 2
 
     def test_iter(self):
-        rt = RelatedTiers([self.tg_word, self.tg_phone])
+        rt = TierGroup([self.tg_word, self.tg_phone])
 
         assert [x.name for x in rt] == [self.tg_word.name, self.tg_phone.name]
     
     def test_get_intervals_at_time(self):
-        rt = RelatedTiers([self.tg_word, self.tg_phone])
+        rt = TierGroup([self.tg_word, self.tg_phone])
 
         target_time = 5
         idx1 = rt[0].get_interval_at_time(5)


### PR DESCRIPTION
Rename `RelatedTiers` class to `TierGroup` class. Better matches behavior of the class within `AlignedTextGrid` objects.