### PR TITLE
.get_seq_by_relative_tieridx -> .get_tierwise

### DIFF
--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -442,7 +442,7 @@ class SequenceInterval:
         else:
             return None
     
-    def get_seq_by_relative_tieridx(
+    def get_tierwise(
             self,
             idx:int = 0
         ):

--- a/tests/test_sequences/test_sequences.py
+++ b/tests/test_sequences/test_sequences.py
@@ -74,7 +74,7 @@ class TestSequenceIntervalDefault:
 
     def test_defaul_getby(self):
         local_sample = self.SampleClassI()
-        assert local_sample.get_seq_by_relative_tieridx(1) is None
+        assert local_sample.get_tierwise(1) is None
 
 class TestSuperSubClassSetting:
     class LocalClassA(SequenceInterval):

--- a/tests/test_tiers/test_SequenceTier.py
+++ b/tests/test_tiers/test_SequenceTier.py
@@ -222,13 +222,13 @@ class TestIntierSetting:
             )
 
         entry = tier[0]
-        assert entry.get_seq_by_relative_tieridx(0) is entry
-        assert entry.get_seq_by_relative_tieridx(1) is entry.fol
+        assert entry.get_tierwise(0) is entry
+        assert entry.get_tierwise(1) is entry.fol
         
         entry2 = tier[2]
-        assert entry2.get_seq_by_relative_tieridx(-1) is entry2.prev
+        assert entry2.get_tierwise(-1) is entry2.prev
         with pytest.raises(IndexError):
-            _ =  entry2.get_seq_by_relative_tieridx(1)
+            _ =  entry2.get_tierwise(1)
 
 class TestTierPop:
     interval1 = Interval(0,1,"one")


### PR DESCRIPTION
The original name was a bit of an unfortunate page out of the tidyverse function naming book