### PR TITLE
121 feature request named accessors

### DIFF
--- a/src/aligned_textgrid/mixins/tiermixins.py
+++ b/src/aligned_textgrid/mixins/tiermixins.py
@@ -50,6 +50,24 @@ class TierGroupMixins:
     def __contains__(self, item):
         return item in self.tier_list
     
+    def __getattr__(
+            self,
+            name: str
+    ):
+        entry_class_names = [x.__name__ for x in self.entry_classes]
+        match_list = [x  for x in entry_class_names if x == name]
+
+        if len(match_list) == 1:
+            match_idx = entry_class_names.index(name)
+            self.__setattr__(name, self.tier_list[match_idx])
+            return self.tier_list[match_idx]
+        
+        if len(match_list) > 1:
+            raise AttributeError(f"{type(self).__name__} has multiple entry classes for {name}")
+        
+        if len(match_list) < 1:
+            raise AttributeError(f"{type(self).__name__} has no attribute {name}")
+    
     def __getitem__(
             self,
             idx: int|list

--- a/tests/test_tiers/test_PointTier.py
+++ b/tests/test_tiers/test_PointTier.py
@@ -106,3 +106,39 @@ class TestPointGroup:
 
         nearest = point_group.get_nearest_points_index(1.25)
         assert len(nearest) == 2
+
+class TestAccessors:
+    class MyPointClassA(SequencePoint):
+        def __init__(self, point):
+            super().__init__(point)
+    
+    class MyPointClassB(SequencePoint):
+        def __init__(self, point):
+            super().__init__(point)
+    
+    point_a = Point(1, "a")
+    point_b = Point(2, "b")
+    point_c = Point(1.5, "c")
+    point_d = Point(2.5, "d")        
+
+    point_tier1 = PointTier(name = "test1", entries = [point_a, point_b])
+    point_tier2 = PointTier(name = "test2", entries = [point_c, point_d])
+
+    seq_point_tier1 = SequencePointTier(point_tier1, entry_class=MyPointClassA)
+    seq_point_tier2 = SequencePointTier(point_tier2, entry_class=MyPointClassB)
+    seq_point_tier3 = SequencePointTier(point_tier2, entry_class=MyPointClassA)
+
+    seq_point_group1 = PointsGroup(tiers = [seq_point_tier1, seq_point_tier2])
+    seq_point_group2 = PointsGroup(tiers = [seq_point_tier1, seq_point_tier3])
+
+    def test_successful_access(self):
+        assert self.seq_point_group1.MyPointClassA
+        assert isinstance(self.seq_point_group1.MyPointClassA[0], self.MyPointClassA)
+    
+    def test_missing_access(self):
+       with pytest.raises(AttributeError, match="has no attribute"):
+           self.seq_point_group1.SequencePoint
+
+    def test_too_many(self, match = "has multiple entry classes"):
+        with pytest.raises(AttributeError):
+            self.seq_point_group2.MyPointClassA


### PR DESCRIPTION
Added a `_getattr__` magic method for TierGroup and PointsGroup (via the TierGroupMixins). Tiers can now be accessed from tiergroups as attributes with the name of the entry class.