### PR TITLE
set .within on tiergroups

### DIFF
--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -70,6 +70,8 @@ class AlignedTextGrid(WithinMixins):
 
         self.tier_groups = self._relate_tiers()
         self.contains = self.tier_groups
+        for tgr in self.tier_groups:
+            tgr.within = self
         self.entry_classes = [[tier.entry_class for tier in tg] for tg in self.tier_groups]
 
     

--- a/tests/test_within.py
+++ b/tests/test_within.py
@@ -114,6 +114,15 @@ class TestWithinTG:
         entry_classes=entry_classes
     )
 
+    def test_within_setting(self): 
+        tgr0 = self.one_tg[0]
+        tier0 = self.one_tg[0][0]
+        interval0 = self.one_tg[0][0][0]
+
+        assert interval0.within is tier0
+        assert tier0.within is tgr0
+        assert tgr0.within is self.one_tg
+
 
     def test_classes_correct(self):
         phone_interval = self.one_tg[0].Phone[0]


### PR DESCRIPTION
This was a relatively small addition to AlignedTextGrid.__init__()