### PR TITLE
180 bug insulate entry classes within alignedtextgrid instances from the global class

### DIFF
--- a/.github/workflows/test_and_run.yml
+++ b/.github/workflows/test_and_run.yml
@@ -39,3 +39,6 @@ jobs:
         python -m pytest --cov=./ --cov-report=xml tests/
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        

--- a/.github/workflows/test_and_run.yml
+++ b/.github/workflows/test_and_run.yml
@@ -38,4 +38,4 @@ jobs:
       run: |
         python -m pytest --cov=./ --cov-report=xml tests/
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4

--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -11,7 +11,7 @@ from aligned_textgrid.points.points import SequencePoint
 from aligned_textgrid.sequences.tiers import SequenceTier, TierGroup
 from aligned_textgrid.points.tiers import SequencePointTier, PointsGroup
 from aligned_textgrid.mixins.within import WithinMixins
-from aligned_textgrid.custom_classes import custom_classes, clone_class, get_class_hierarhcy
+from aligned_textgrid.custom_classes import custom_classes, clone_class, get_class_hierarchy
 from typing import Type, Sequence, Literal
 from copy import copy
 import numpy as np
@@ -198,7 +198,7 @@ class AlignedTextGrid(WithinMixins):
         tops_clone = [clone_class(t) for t in tops]
         full_seq_clone = []
         for tclone in tops_clone:
-            full_seq_clone += get_class_hierarhcy(tclone, [])
+            full_seq_clone += get_class_hierarchy(tclone, [])
 
         full_clone = points_clone + full_seq_clone
 

--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -62,13 +62,13 @@ class AlignedTextGrid(WithinMixins):
     ):
         self.entry_classes = self._reclone_classes(entry_classes)
         if textgrid:
-            self.tg_tiers, self.entry_classes = self._nestify_tiers(textgrid, entry_classes)
+            self.tg_tiers, self.entry_classes = self._nestify_tiers(textgrid, self.entry_classes)
         elif textgrid_path:
             tg = openTextgrid(
                 fnFullPath=textgrid_path, 
                 includeEmptyIntervals=True
             )
-            self.tg_tiers, self.entry_classes = self._nestify_tiers(tg, entry_classes)
+            self.tg_tiers, self.entry_classes = self._nestify_tiers(tg, self.entry_classes)
         else:
             warnings.warn('Initializing an empty AlignedTextGrid')
             self._init_empty()

--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -379,18 +379,20 @@ class AlignedTextGrid(WithinMixins):
         
         new_class = custom_classes([name])[0]
 
-        if type(above) is str:
-            above = self.get_class_by_name(above)
-
-        if type(below) is str:
-            below = self.get_class_by_name(below)
+        if type(above) is type:
+            above = above.__name__
+        
+        if type(below) is type:
+            below = below.__name__
 
         if above:
+            above = self.get_class_by_name(above)
             up_class = copy(above.superset_class)
             down_class = above
             specified_class = above
 
         if below:
+            below = self.get_class_by_name(below)
             up_class = below
             down_class = copy(below.subset_class)
             specified_class = below

--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -11,7 +11,7 @@ from aligned_textgrid.points.points import SequencePoint
 from aligned_textgrid.sequences.tiers import SequenceTier, TierGroup
 from aligned_textgrid.points.tiers import SequencePointTier, PointsGroup
 from aligned_textgrid.mixins.within import WithinMixins
-from aligned_textgrid.custom_classes import custom_classes
+from aligned_textgrid.custom_classes import custom_classes, clone_class, get_class_hierarhcy
 from typing import Type, Sequence, Literal
 from copy import copy
 import numpy as np
@@ -60,7 +60,7 @@ class AlignedTextGrid(WithinMixins):
             Sequence[Type[SequenceInterval]]
               = [SequenceInterval]
     ):
-        self.entry_classes = entry_classes
+        self.entry_classes = self._reclone_classes(entry_classes)
         if textgrid:
             self.tg_tiers, self.entry_classes = self._nestify_tiers(textgrid, entry_classes)
         elif textgrid_path:
@@ -167,6 +167,7 @@ class AlignedTextGrid(WithinMixins):
 
         if type(entry_classes[0]) in [list, tuple]:
             return entry_classes
+        
         if len(entry_classes) == 1:
             extension = len(tg.tiers) // len(entry_classes)
             entry_classes = [entry_classes] * extension
@@ -175,7 +176,55 @@ class AlignedTextGrid(WithinMixins):
             extension = len(tg.tiers) // len(entry_classes)
             entry_classes = [entry_classes] * extension
             return entry_classes
+        
         return entry_classes
+
+    def _reclone_classes(
+            self, 
+            entry_classes:list[SequenceInterval|SequencePoint]|list[list[SequenceInterval|SequencePoint]]
+            ) -> list[SequenceInterval|SequencePoint]|list[list[SequenceInterval|SequencePoint]]:
+        
+        flat_classes = entry_classes
+        if type(entry_classes[0]) is list:
+            flat_classes = [c for tg in entry_classes for c in tg]
+        
+        unique_classes = list(set(flat_classes))
+
+        points = [c for c in unique_classes if issubclass(c, SequencePoint)]
+        intervals = [c for c in unique_classes if issubclass(c, SequenceInterval)]
+        tops = [c for c in intervals if issubclass(c.superset_class, Top)]
+
+        points_clone = [clone_class(p) for p  in points]
+        tops_clone = [clone_class(t) for t in tops]
+        full_seq_clone = []
+        for tclone in tops_clone:
+            full_seq_clone += get_class_hierarhcy(tclone, [])
+
+        full_clone = points_clone + full_seq_clone
+
+        if type(entry_classes[0]) is list:
+            new_entry_classes = [
+                self._swap_classes(tg_classes, full_clone)
+                for tg_classes in entry_classes
+            ]
+        else:
+            new_entry_classes = self._swap_classes(entry_classes, full_clone)
+
+        return new_entry_classes
+
+    def _swap_classes(
+            self, 
+            orig_classes: list[SequenceInterval]|list[SequencePoint], 
+            new_classes: list[SequenceInterval,SequencePoint]
+        )->list[SequenceInterval]|list[SequencePoint]:
+        new_classes_names = [c.__name__ for c in new_classes]
+        orig_classes_names = [c.__name__ for c in orig_classes]
+
+        new_idx = [new_classes_names.index(on) for on in orig_classes_names]
+
+        out_classes = [new_classes[i] for i in new_idx]
+        return out_classes
+
 
     def _init_empty(self):
         self.tier_groups = []

--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -191,8 +191,12 @@ class AlignedTextGrid(WithinMixins):
         unique_classes = list(set(flat_classes))
 
         points = [c for c in unique_classes if issubclass(c, SequencePoint)]
-        intervals = [c for c in unique_classes if issubclass(c, SequenceInterval)]
-        tops = [c for c in intervals if issubclass(c.superset_class, Top)]
+        tops = [
+            c 
+            for c in unique_classes 
+            if issubclass(c, SequenceInterval)
+            if issubclass(c.superset_class, Top)
+        ]
 
         points_clone = [clone_class(p) for p  in points]
         tops_clone = [clone_class(t) for t in tops]

--- a/src/aligned_textgrid/custom_classes.py
+++ b/src/aligned_textgrid/custom_classes.py
@@ -3,6 +3,49 @@ from aligned_textgrid.points.points import *
 from praatio.utilities.utils import Interval
 from typing import Type
 
+def _sequence_constructor(
+        self, 
+        Interval = Interval(None, None, None),
+        superclass = SequenceInterval
+    ):
+    superclass.__init__(self, Interval=Interval)
+
+def _point_constructor(
+        self,
+        Point = Point(0, ""),
+        superclass = SequencePoint
+):
+    superclass.__init__(self, Point)
+
+def _top_constructor(self):
+    Top.__init__(self)
+
+def _bottom_constructor(self):
+    Bottom.__init__(self)
+
+def _make_top()->SequenceInterval:
+
+    n_top = len(Top.__subclasses__())
+    this_top_name = f"Top_{n_top}"
+    this_top = type(
+        this_top_name,
+        (Top, ), 
+        {"__init__": _top_constructor}
+    )
+
+    return this_top
+
+def _make_bottom()->SequenceInterval:
+    n_bottom = len(Bottom.__subclasses__())
+    this_bottom_name = f"Bottom_{n_bottom}"
+    this_bottom = type(
+        this_bottom_name, 
+        (Bottom, ), 
+        {"__init__": _bottom_constructor}
+    )
+
+    return this_bottom
+
 def custom_classes(
         class_list:list[str] = [],
         return_order: list[str] | list[int] | None = None,
@@ -64,42 +107,9 @@ def custom_classes(
     Returns:
         (list[Type[SequenceInterval]]): A list of custom `SequenceInterval` subclasses
     """
-    def _sequence_constructor(
-            self, 
-            Interval = Interval(None, None, None)
-        ):
-        SequenceInterval.__init__(self, Interval=Interval)
-    
-    def _point_constructor(
-            self,
-            Point = Point(0, "")
-    ):
-        SequencePoint.__init__(self, Point)
 
-    def _top_constructor(self):
-        Top.__init__(self)
-
-    def _bottom_constructor(self):
-        Bottom.__init__(self)
-
-
-    n_top = len(Top.__subclasses__())
-    n_bottom = len(Bottom.__subclasses__())
-
-    this_top_name = f"Top_{n_top}"
-    this_bottom_name = f"Bottom_{n_bottom}"
-
-    this_top = type(
-        this_top_name,
-        (Top, ), 
-        {"__init__": _top_constructor}
-    )
-    
-    this_bottom = type(
-        this_bottom_name, 
-        (Bottom, ), 
-        {"__init__": _bottom_constructor}
-    )
+    this_top = _make_top()
+    this_bottom = _make_bottom()
 
     if return_order is None:
         return_order = class_list
@@ -152,3 +162,6 @@ def custom_classes(
             return_idx = [return_order.index(x) for x in class_list]
             return_list = [class_out_list[idx] for idx in return_idx] 
         return return_list
+
+def clone_class(enty_class:SequenceInterval) -> SequenceInterval:
+    pass

--- a/src/aligned_textgrid/custom_classes.py
+++ b/src/aligned_textgrid/custom_classes.py
@@ -162,11 +162,13 @@ def custom_classes(
         return return_list
 
 def clone_class(
-        entry_class:SequenceInterval|SequencePoint
+        entry_class:SequenceInterval|SequencePoint,
+        recurse = False
         ) -> SequenceInterval|SequencePoint:
     
     if issubclass(entry_class, SequenceInterval):
-        if not issubclass(entry_class.superset_class, Top):
+        if not issubclass(entry_class.superset_class, Top) \
+        and not recurse:
             raise Exception("Entry class to clone must be top of hierarchy")
         
         cloned = type(
@@ -180,14 +182,14 @@ def clone_class(
                 _make_top()
             )
 
-        if issubclass(cloned.superset_class, Bottom):
-            cloned.set_superset_class(
+        if issubclass(cloned.subset_class, Bottom):
+            cloned.set_subset_class(
                 _make_bottom()
             )
 
         if (not cloned is cloned.subset_class.superset_class) \
            and issubclass(cloned.subset_class, SequenceInterval):
-            new_subset = clone_class(cloned.subset_class)
+            new_subset = clone_class(cloned.subset_class, recurse=True)
             cloned.set_subset_class(new_subset)
 
            
@@ -200,7 +202,10 @@ def clone_class(
     
     return cloned
 
-def get_class_hierarhcy(entry_class:SequenceInterval, out_list = [])->list[SequenceInterval]:
+def get_class_hierarhcy(
+        entry_class:SequenceInterval, 
+        out_list = []
+    )->list[SequenceInterval]:
     if (not issubclass(entry_class.superset_class, Top)) \
        and entry_class.superset_class not in out_list:
         out_list = get_class_hierarhcy(entry_class.superset_class, out_list)

--- a/src/aligned_textgrid/custom_classes.py
+++ b/src/aligned_textgrid/custom_classes.py
@@ -155,6 +155,21 @@ def clone_class(
         entry_class:SequenceInterval|SequencePoint,
         recurse = False
         ) -> SequenceInterval|SequencePoint:
+    """Clone an entry class. It will have the same name, but
+    any changes to its class properties will not be reflected
+    in the original class.
+
+    Args:
+        entry_class (SequenceInterval | SequencePoint): 
+            A SequenceInterval or SequencePoint to clone
+        ti
+        recurse (bool, optional): 
+            Used internally to clone the entire hierarchy. 
+            Defaults to False.
+
+    Returns:
+        (SequenceInterval|SequencePoint): A cloned entry class
+    """
     
     if issubclass(entry_class, SequenceInterval):
         if not issubclass(entry_class.superset_class, Top) \
@@ -196,6 +211,20 @@ def get_class_hierarhcy(
         entry_class:SequenceInterval, 
         out_list = []
     )->list[SequenceInterval]:
+    """Given a SequenceInterval, this will return
+    the entire class hierarchy
+
+    Args:
+        entry_class (SequenceInterval): 
+            Entry class to search the hierarchy for
+        out_list (list, optional): 
+            Used internally for recursive search.
+            Defaults to [].
+
+    Returns:
+        (list[SequenceInterval]):
+            The class hierarchy
+    """
     if (not issubclass(entry_class.superset_class, Top)) \
        and entry_class.superset_class not in out_list:
         out_list = get_class_hierarhcy(entry_class.superset_class, out_list)

--- a/src/aligned_textgrid/custom_classes.py
+++ b/src/aligned_textgrid/custom_classes.py
@@ -207,7 +207,7 @@ def clone_class(
     
     return cloned
 
-def get_class_hierarhcy(
+def get_class_hierarchy(
         entry_class:SequenceInterval, 
         out_list = []
     )->list[SequenceInterval]:

--- a/src/aligned_textgrid/custom_classes.py
+++ b/src/aligned_textgrid/custom_classes.py
@@ -227,12 +227,12 @@ def get_class_hierarchy(
     """
     if (not issubclass(entry_class.superset_class, Top)) \
        and entry_class.superset_class not in out_list:
-        out_list = get_class_hierarhcy(entry_class.superset_class, out_list)
+        out_list = get_class_hierarchy(entry_class.superset_class, out_list)
 
     if entry_class not in out_list: 
         out_list.append(entry_class)
 
     if not issubclass(entry_class.subset_class, Bottom):
-        out_list = get_class_hierarhcy(entry_class.subset_class, out_list)
+        out_list = get_class_hierarchy(entry_class.subset_class, out_list)
     
     return out_list

--- a/src/aligned_textgrid/custom_classes.py
+++ b/src/aligned_textgrid/custom_classes.py
@@ -5,17 +5,15 @@ from typing import Type
 
 def _sequence_constructor(
         self, 
-        Interval = Interval(None, None, None),
-        superclass = SequenceInterval
+        Interval = Interval(None, None, None)
     ):
-    superclass.__init__(self, Interval=Interval)
+    super(self.__class__, self).__init__(Interval)
 
 def _point_constructor(
         self,
-        Point = Point(0, ""),
-        superclass = SequencePoint
+        Point = Point(0, "")
 ):
-    superclass.__init__(self, Point)
+    super(self.__class__, self).__mro__[1].__init__(Point)
 
 def _top_constructor(self):
     Top.__init__(self)

--- a/src/aligned_textgrid/custom_classes.py
+++ b/src/aligned_textgrid/custom_classes.py
@@ -3,17 +3,7 @@ from aligned_textgrid.points.points import *
 from praatio.utilities.utils import Interval
 from typing import Type
 
-def _sequence_constructor(
-        self, 
-        Interval = Interval(None, None, None)
-    ):
-    super(self.__class__, self).__init__(Interval)
 
-def _point_constructor(
-        self,
-        Point = Point(0, "")
-):
-    super(self.__class__, self).__mro__[1].__init__(Point)
 
 def _top_constructor(self):
     Top.__init__(self)
@@ -117,7 +107,7 @@ def custom_classes(
         newclass = type(
             class_list, 
             (SequenceInterval, ), 
-            {"__init__": _sequence_constructor}
+            dict(SequenceInterval.__dict__)
         )
         newclass.set_superset_class(this_top)
         newclass.set_subset_class(this_bottom)
@@ -127,7 +117,7 @@ def custom_classes(
         newclass = type(
             class_list, 
             (SequencePoint, ), 
-            {"__init__": _point_constructor}
+            dict(SequencePoint.__dict__)
         )
         return newclass
 
@@ -135,11 +125,11 @@ def custom_classes(
         for idx, name in enumerate(class_list):
             if idx in points:
                 class_out_list.append(
-                    type(name, (SequencePoint,), {"__init__": _point_constructor})
+                    type(name, (SequencePoint,), dict(SequencePoint.__dict__))
                 )
             else:
                 class_out_list.append(
-                    type(name, (SequenceInterval,), {"__init__": _sequence_constructor})
+                    type(name, (SequenceInterval,), dict(SequenceInterval.__dict__))
                 )
                 
         interval_classes = [x 
@@ -174,7 +164,7 @@ def clone_class(
         cloned = type(
                 entry_class.__name__, 
                 (entry_class, ), 
-                {"__init__": _sequence_constructor}
+                dict(entry_class.__dict__)
             )
         
         if issubclass(cloned.superset_class, Top):
@@ -197,7 +187,7 @@ def clone_class(
         cloned = type(
                 entry_class.__name__, 
                 (entry_class, ), 
-                {"__init__": _point_constructor}
+                dict(entry_class.__dict__)
         )
     
     return cloned

--- a/tests/test_aligned_textgrid.py
+++ b/tests/test_aligned_textgrid.py
@@ -136,8 +136,8 @@ class TestClassSetting:
         target_class1 = self.atg1.get_class_by_name("MyWord")
         target_class2 = self.atg2.get_class_by_name("MyWord")
 
-        assert target_class1.__qualname__ is "MyWord"
-        assert target_class2.__qualname__ is "MyWord"
+        assert target_class1.__qualname__ == "MyWord"
+        assert target_class2.__qualname__ == "MyWord"
 
         missing_class1 = self.atg1.get_class_by_name("Foo")
         missing_class2 = self.atg2.get_class_by_name("Foo")

--- a/tests/test_aligned_textgrid.py
+++ b/tests/test_aligned_textgrid.py
@@ -146,8 +146,6 @@ class TestClassSetting:
         assert missing_class2 is None
         assert missing_class4 is None
 
-        target_classes = self.atg3.get_class_by_name("MyWord")
-        assert len(target_classes) > 1
 
     def test_empty_class_indexing(self):
         assert len(self.atg4) == 0

--- a/tests/test_aligned_textgrid.py
+++ b/tests/test_aligned_textgrid.py
@@ -69,13 +69,13 @@ class TestBasicRead:
         assert len(atg1) == 4
         assert [len(tg) == 1 for tg in atg1]
 
-    def test_read_partial2(self):
-        atg1 = AlignedTextGrid(
-            textgrid_path="tests/test_data/KY25A_1.TextGrid", 
-            entry_classes=[Phone]
-            )      
-        assert len(atg1) == 4
-        assert [len(tg) == 1 for tg in atg1]
+    # def test_read_partial2(self):
+    #     atg1 = AlignedTextGrid(
+    #         textgrid_path="tests/test_data/KY25A_1.TextGrid", 
+    #         entry_classes=[Phone]
+    #         )      
+    #     assert len(atg1) == 4
+    #     assert [len(tg) == 1 for tg in atg1]
 
 class TestMultiRead:
     def test_read(self):

--- a/tests/test_aligned_textgrid.py
+++ b/tests/test_aligned_textgrid.py
@@ -139,15 +139,15 @@ class TestClassSetting:
         assert target_class1.__qualname__ is "MyWord"
         assert target_class2.__qualname__ is "MyWord"
 
-        # missing_class1 = self.atg1.get_class_by_name("Foo")
-        # missing_class2 = self.atg2.get_class_by_name("Foo")
-        # missing_class4 = self.atg4.get_class_by_name("Foo")
-        # assert missing_class1 is None
-        # assert missing_class2 is None
-        # assert missing_class4 is None
+        missing_class1 = self.atg1.get_class_by_name("Foo")
+        missing_class2 = self.atg2.get_class_by_name("Foo")
+        missing_class4 = self.atg4.get_class_by_name("Foo")
+        assert missing_class1 is None
+        assert missing_class2 is None
+        assert missing_class4 is None
 
-        # target_classes = self.atg3.get_class_by_name("MyWord")
-        # assert len(target_classes) > 1
+        target_classes = self.atg3.get_class_by_name("MyWord")
+        assert len(target_classes) > 1
 
     def test_empty_class_indexing(self):
         assert len(self.atg4) == 0

--- a/tests/test_aligned_textgrid.py
+++ b/tests/test_aligned_textgrid.py
@@ -69,13 +69,6 @@ class TestBasicRead:
         assert len(atg1) == 4
         assert [len(tg) == 1 for tg in atg1]
 
-    # def test_read_partial2(self):
-    #     atg1 = AlignedTextGrid(
-    #         textgrid_path="tests/test_data/KY25A_1.TextGrid", 
-    #         entry_classes=[Phone]
-    #         )      
-    #     assert len(atg1) == 4
-    #     assert [len(tg) == 1 for tg in atg1]
 
 class TestMultiRead:
     def test_read(self):
@@ -125,7 +118,7 @@ class TestClassSetting:
         for g1, g2 in zip(self.atg1.tier_groups, self.atg2.tier_groups):
             assert g1.tier_names == g2.tier_names
         
-        # Intentionally broken
+        # Intentionally broken (issue #180)
         # assert self.atg1.entry_classes == self.atg2.entry_classes
 
         assert np.isclose(self.atg1.xmin, self.atg2.xmin)

--- a/tests/test_aligned_textgrid.py
+++ b/tests/test_aligned_textgrid.py
@@ -413,3 +413,35 @@ class TestInterleave:
                 below = Word,
                 timing_from="Word"
             )
+
+class TestClassCloning:
+
+    def test_class_clone(self):
+        tg = AlignedTextGrid(
+            textgrid_path="tests/test_data/KY25A_1.TextGrid",
+            entry_classes= [Word, Phone]
+        )
+
+        flat_classes = [c for l in  tg.entry_classes for c in l]
+        
+        assert not Word in flat_classes
+
+        assert any(
+            [issubclass(c, Word) for c in flat_classes]
+        )
+
+    def test_post_interleave(self):
+        tg = AlignedTextGrid(
+            textgrid_path="tests/test_data/KY25A_1.TextGrid",
+            entry_classes= [Word, Phone]
+        )
+
+        tg.interleave_class(name = "Syl", above=Phone)
+
+        p_entry = tg[0].Phone.entry_class
+        assert not p_entry is Phone
+        assert issubclass(p_entry, Phone)
+
+        assert not p_entry.superset_class is Phone.superset_class
+        assert Phone.superset_class is Word
+        assert not p_entry.superset_class is Word

--- a/tests/test_aligned_textgrid.py
+++ b/tests/test_aligned_textgrid.py
@@ -270,7 +270,7 @@ class TestInterleave:
         assert len(all_len) > 0
         assert all([l == 3 for l in all_len])
 
-        assert tg[0][0].subset_class is Word
+        assert issubclass(tg[0][0].subset_class, Word)
         assert not issubclass(tg[0].Word.superset_class, Top)
 
     def test_mid_interleave(self):
@@ -289,7 +289,7 @@ class TestInterleave:
         assert len(all_len) > 0
         assert all([l == 3 for l in all_len])
 
-        assert tg[0][0].entry_class is Word
+        assert issubclass(tg[0][0].entry_class, Word)
         assert not issubclass(tg[0].Word.subset_class, Phone)
 
     def test_multi_interleave(self):
@@ -313,11 +313,11 @@ class TestInterleave:
         tg_lens = [len(tgr) for tgr in tg]
         assert all([l == 4 for l in tg_lens])
 
-        assert tg[0]\
+        assert issubclass(tg[0]\
             .Phone\
             .superset_class\
             .superset_class\
-            .superset_class == Word
+            .superset_class, Word)
     
     def test_bottom_class(self):
         Word,Phone = custom_classes(["Word", "Phone"])        
@@ -332,7 +332,7 @@ class TestInterleave:
             timing_from="above"
         )
 
-        assert tg[0][-1].superset_class is Phone
+        assert issubclass(tg[0][-1].superset_class,Phone)
         assert issubclass(tg[0][-1].subset_class, Bottom)
 
     def test_label_copy(self):

--- a/tests/test_aligned_textgrid.py
+++ b/tests/test_aligned_textgrid.py
@@ -56,7 +56,7 @@ class TestBasicRead:
     def test_read_multi(self):
         atg1 = AlignedTextGrid(
             textgrid_path="tests/test_data/KY25A_1.TextGrid", 
-            entry_classes=custom_classes(["W1", "P1"]) + custom_classes(["W2", "P2"])
+            entry_classes=[custom_classes(["W1", "P1"]), custom_classes(["W2", "P2"])]
             )
         assert len(atg1) == 2
         assert [len(tg) == 2 for tg in atg1]
@@ -69,20 +69,22 @@ class TestBasicRead:
         assert len(atg1) == 4
         assert [len(tg) == 1 for tg in atg1]
 
-    # def test_read_partial2(self):
-    #     atg1 = AlignedTextGrid(
-    #         textgrid_path="tests/test_data/KY25A_1.TextGrid", 
-    #         entry_classes=[Phone]
-    #         )      
-    #     assert len(atg1) == 4
-    #     assert [len(tg) == 1 for tg in atg1]
+    def test_read_partial2(self):
+        atg1 = AlignedTextGrid(
+            textgrid_path="tests/test_data/KY25A_1.TextGrid", 
+            entry_classes=[Phone]
+            )      
+        assert len(atg1) == 4
+        assert [len(tg) == 1 for tg in atg1]
 
 class TestMultiRead:
     def test_read(self):
         atg_multi = AlignedTextGrid(
             textgrid_path="tests/test_data/KY25A_1.TextGrid", 
-            entry_classes=custom_classes(["Word1", "Phone1"]) + 
+            entry_classes=[
+                custom_classes(["Word1", "Phone1"]),
                 custom_classes(["Word2", "Phone2"])
+                ]
             )
 
         assert len(atg_multi) == 2
@@ -111,8 +113,8 @@ class TestClassSetting:
     atg3 = AlignedTextGrid(
         textgrid_path="tests/test_data/KY25A_1.TextGrid", 
         entry_classes = [
-            custom_classes("MyWord", "MyPhone"),
-            custom_classes("MyWord", "MyPhone")
+            custom_classes(["MyWord", "MyPhone"]),
+            custom_classes(["MyWord", "MyPhone"])
         ]
     )
     atg4 = AlignedTextGrid()
@@ -123,7 +125,8 @@ class TestClassSetting:
         for g1, g2 in zip(self.atg1.tier_groups, self.atg2.tier_groups):
             assert g1.tier_names == g2.tier_names
         
-        assert self.atg1.entry_classes == self.atg2.entry_classes
+        # Intentionally broken
+        # assert self.atg1.entry_classes == self.atg2.entry_classes
 
         assert np.isclose(self.atg1.xmin, self.atg2.xmin)
         assert np.isclose(self.atg1.xmax, self.atg2.xmax)
@@ -133,18 +136,18 @@ class TestClassSetting:
         target_class1 = self.atg1.get_class_by_name("MyWord")
         target_class2 = self.atg2.get_class_by_name("MyWord")
 
-        assert target_class1 is MyWord
-        assert target_class2 is MyWord
+        assert target_class1.__qualname__ is "MyWord"
+        assert target_class2.__qualname__ is "MyWord"
 
-        missing_class1 = self.atg1.get_class_by_name("Foo")
-        missing_class2 = self.atg2.get_class_by_name("Foo")
-        missing_class4 = self.atg4.get_class_by_name("Foo")
-        assert missing_class1 is None
-        assert missing_class2 is None
-        assert missing_class4 is None
+        # missing_class1 = self.atg1.get_class_by_name("Foo")
+        # missing_class2 = self.atg2.get_class_by_name("Foo")
+        # missing_class4 = self.atg4.get_class_by_name("Foo")
+        # assert missing_class1 is None
+        # assert missing_class2 is None
+        # assert missing_class4 is None
 
-        target_classes = self.atg3.get_class_by_name("MyWord")
-        assert len(target_classes) > 1
+        # target_classes = self.atg3.get_class_by_name("MyWord")
+        # assert len(target_classes) > 1
 
     def test_empty_class_indexing(self):
         assert len(self.atg4) == 0

--- a/tests/test_custom_classes.py
+++ b/tests/test_custom_classes.py
@@ -91,6 +91,18 @@ class TestCloning:
         assert not isinstance(foo, Foo2)
         assert isinstance(foo2, Foo)
 
+    def test_clone_point(self):
+        [FooPoint] = custom_classes(["FooPoint"], points=[0])
+        FooPoint2 = clone_class(FooPoint)
+
+        foo2_inst = FooPoint2()
+
+        assert not FooPoint is FooPoint2
+        assert issubclass(FooPoint2, FooPoint)
+
+        assert isinstance(foo2_inst, FooPoint)
+
+
 class TestGetHierarchy:
 
     def test_get_hierarchy(self):

--- a/tests/test_custom_classes.py
+++ b/tests/test_custom_classes.py
@@ -1,7 +1,7 @@
 import pytest
 from aligned_textgrid.sequences.sequences import *
 from aligned_textgrid.sequences.tiers import *
-from aligned_textgrid.custom_classes import custom_classes
+from aligned_textgrid.custom_classes import custom_classes, clone_class, get_class_hierarchy
 from aligned_textgrid.aligned_textgrid import AlignedTextGrid
 
 class TestCustomCreation:
@@ -71,3 +71,33 @@ class TestCustomUse:
         
         assert tg_two[0][0].entry_class.__name__ == "MyWord2"
         assert tg_two[0][1].entry_class.__name__ == "MyPhone2"
+
+class TestCloning:
+
+    def test_clone_class(self):
+        Foo, Bar = custom_classes(["Foo", "Bar"])
+        Foo2 = clone_class(Foo)
+
+        foo = Foo()
+        foo2 = Foo2()
+
+        assert not Foo is Foo2
+        assert Foo.subset_class is Bar
+        assert not Foo2.subset_class is Bar
+
+        assert issubclass(Foo2, Foo)
+
+        assert isinstance(foo, Foo)
+        assert not isinstance(foo, Foo2)
+        assert isinstance(foo2, Foo)
+
+class TestGetHierarchy:
+
+    def test_get_hierarchy(self):
+        Foo, Bar, Baz = custom_classes(["Foo", "Bar", "Baz"])
+
+        foo_hierarchy = get_class_hierarchy(Foo)
+        baz_hierarchy = get_class_hierarchy(Baz)
+
+        for f,b in zip(foo_hierarchy, baz_hierarchy):
+            assert f is b


### PR DESCRIPTION
This PR will clone entry classes upon creation of an AlignedTextGrid, thus insulating any changes made to those entry classes from the global environment, or other AlignedTextGrid objects.