### PR TITLE
Flexibilization of ATG object creation 

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -53,18 +53,6 @@ website:
               - usage/05_Outputs/00_to_textgrid.ipynb
               - usage/05_Outputs/01_to_dataframe.ipynb              
               - usage/05_Outputs/02_pickling.ipynb
-  #         - section: Processing patterns
-  #           contents: 
-  #             - getting-started/single-file.qmd
-  #             - getting-started/directory.qmd
-  #         - section: Customizing a recoding scheme
-  #           contents:
-  #             - getting-started/rule-scheme-basics.qmd
-  #             - getting-started/rule-application.qmd
-  #             - section: Details
-  #               contents:
-  #                 - getting-started/condition-attributes.qmd
-  #                 - getting-started/condition-relations.qmd
 
 format:
   html: 

--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -113,6 +113,20 @@ class AlignedTextGrid(Sequence, WithinMixins):
     def __setstate__(self, d):
         self.__dict__ = d
 
+    def _process_textgrid_arg(self, arg):
+        if isinstance(arg, str) or isinstance(arg, Path):
+            arg_str = str(arg)
+            tg = openTextgrid(
+                fnFullPath=arg_str, 
+                includeEmptyIntervals=True,
+                duplicateNamesMode='rename'
+            )
+        
+        if isinstance(arg, Textgrid):
+            tg = arg
+        
+        self.tg_tiers, self.entry_classes = self._nestify_tiers(tg, self.entry_classes)
+
     def _extend_classes(
             self, 
             tg: Textgrid, 

--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -16,6 +16,7 @@ from typing import Type, Sequence, Literal
 from copy import copy
 import numpy as np
 from collections.abc import Sequence
+from pathlib import Path
 import warnings
 
 
@@ -23,9 +24,7 @@ class AlignedTextGrid(Sequence, WithinMixins):
     """An aligned Textgrid
 
     Args:
-        textgrid (Textgrid, optional): A `praatio` TextGrid
-        textgrid_path (str, optional): A path to a TextGrid file to be 
-            read in with `praatio.textgrid.openTextgrid`
+        textgrid (str|Path|praatio.textgrid.Textgrid, optional): A `praatio` TextGrid
         entry_classes (Sequence[Sequence[Type[SequenceInterval]]] | Sequence[Type[SequenceInterval]], optional): 
             If a single list of `SequenceInterval` subclasses is given, they will be
             repeated as many times as necessary to assign a class to every tier. 

--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -54,12 +54,13 @@ class AlignedTextGrid(Sequence, WithinMixins):
 
     def __init__(
         self,
-        textgrid: Textgrid = None,
-        textgrid_path: str =  None,
+        textgrid: Textgrid|str|Path = None,
         entry_classes: 
             Sequence[Sequence[Type[SequenceInterval]]] |
             Sequence[Type[SequenceInterval]]
-              = [SequenceInterval]
+              = [SequenceInterval],
+        *,
+        textgrid_path: str =  None
     ):
         self.entry_classes = self._reclone_classes(entry_classes)
         if textgrid_path:

--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -62,15 +62,11 @@ class AlignedTextGrid(Sequence, WithinMixins):
               = [SequenceInterval]
     ):
         self.entry_classes = self._reclone_classes(entry_classes)
+        if textgrid_path:
+            textgrid = textgrid_path
+
         if textgrid:
-            self.tg_tiers, self.entry_classes = self._nestify_tiers(textgrid, self.entry_classes)
-        elif textgrid_path:
-            tg = openTextgrid(
-                fnFullPath=textgrid_path, 
-                includeEmptyIntervals=True,
-                duplicateNamesMode='rename'
-            )
-            self.tg_tiers, self.entry_classes = self._nestify_tiers(tg, self.entry_classes)
+            self._process_textgrid_arg(textgrid)
         else:
             warnings.warn('Initializing an empty AlignedTextGrid')
             self._init_empty()

--- a/src/aligned_textgrid/points/points.py
+++ b/src/aligned_textgrid/points/points.py
@@ -104,6 +104,10 @@ class  SequencePoint(PrecedenceMixins, InTierMixins, WithinMixins):
     
     ## Properties
     @property
+    def entry_class(self):
+        return self.__class__
+
+    @property
     def fol_distance(self):
         if self.fol and self.fol.time:
             return self.fol.time - self.time

--- a/src/aligned_textgrid/points/points.py
+++ b/src/aligned_textgrid/points/points.py
@@ -7,7 +7,12 @@ from typing_extensions import Self
 import warnings
 import numpy as np
 
-from typing import Union
+import sys
+if sys.version_info >= (3,11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 
 class  SequencePoint(PrecedenceMixins, InTierMixins, WithinMixins):
     """Sequence Points

--- a/src/aligned_textgrid/points/points.py
+++ b/src/aligned_textgrid/points/points.py
@@ -38,7 +38,7 @@ class  SequencePoint(PrecedenceMixins, InTierMixins, WithinMixins):
 
     def __init__(
             self,
-            point = Point(0, "")
+            point: list|tuple|Point|Self = (0, "")
         ):
 
         if isinstance(point, SequencePoint):

--- a/src/aligned_textgrid/points/points.py
+++ b/src/aligned_textgrid/points/points.py
@@ -18,8 +18,30 @@ class  SequencePoint(PrecedenceMixins, InTierMixins, WithinMixins):
     """Sequence Points
     
     Args:
-        point (Point): a `praatio.point` object
+        point (list|tuple|Point|Self):
+            A list or tuple of a time and label value.
     
+    Examples:
+        ```{python}
+        from aligned_textgrid import SequencePoint, SequenceInterval
+
+        first_point = SequencePoint((0, "first"))
+        print(first_point)
+        ```
+
+        ```{python}
+        second_point = SequencePoint((1, "second"))
+        interval = SequenceInterval((0.5, 2, "word"))
+
+        print(
+            first_point.distance_from(second_point)
+        )
+
+        print(
+            first_point.distance_from(interval)
+        )
+        ```
+
     Attributes:
         ...:
             All attributes and methods included in PrecedenceMixins and InTierMixins

--- a/src/aligned_textgrid/points/points.py
+++ b/src/aligned_textgrid/points/points.py
@@ -40,10 +40,12 @@ class  SequencePoint(PrecedenceMixins, InTierMixins, WithinMixins):
             self,
             point = Point(0, "")
         ):
-        super().__init__()
-        if not point:
-            point = Point(None, None)
-        
+
+        if isinstance(point, SequencePoint):
+            point = (point.time, point.label)
+
+        point = Point(*point)
+
         self.time = point.time
         self.label = point.label
 

--- a/src/aligned_textgrid/points/points.py
+++ b/src/aligned_textgrid/points/points.py
@@ -70,6 +70,12 @@ class  SequencePoint(PrecedenceMixins, InTierMixins, WithinMixins):
         if isinstance(point, SequencePoint):
             point = (point.time, point.label)
 
+        if len(point) > 2:
+            raise ValueError((
+                "The tuple to create a SequencePoint should be "
+                "no more than 2 values long. "
+                f"{len(point)} were provided."
+            ))
         point = Point(*point)
 
         self.time = point.time

--- a/src/aligned_textgrid/points/points.py
+++ b/src/aligned_textgrid/points/points.py
@@ -3,7 +3,6 @@ from aligned_textgrid.mixins.mixins import PrecedenceMixins, InTierMixins
 from aligned_textgrid.mixins.within import WithinMixins
 from aligned_textgrid.sequences.tiers import SequenceTier
 from aligned_textgrid.sequences.sequences import SequenceInterval
-from typing_extensions import Self
 import warnings
 import numpy as np
 
@@ -134,7 +133,7 @@ class  SequencePoint(PrecedenceMixins, InTierMixins, WithinMixins):
     def distance_from(
             self, 
             entry: Self|SequenceInterval
-        ) -> Union[float, np.array]:
+        ) -> np.array:
         """Distance from an entry
 
         Args:
@@ -143,12 +142,12 @@ class  SequencePoint(PrecedenceMixins, InTierMixins, WithinMixins):
                 point from
 
         Returns:
-            (float | np.array):
+            (np.array):
                 a single value in the case of a point, a numpy array in
                 the case of an interval.
         """
         if isinstance(entry, SequencePoint):
-            return self.time - entry.time
+            return np.array(self.time - entry.time)
         
         if isinstance(entry, SequenceInterval):
             entry_times = np.array([entry.start, entry.end])

--- a/src/aligned_textgrid/points/tiers.py
+++ b/src/aligned_textgrid/points/tiers.py
@@ -23,10 +23,26 @@ class SequencePointTier(Sequence, TierMixins, WithinMixins):
     """A SequencePointTier class
 
     Args:
-        tier (PointTier | list[Point]): 
-            Either a `praatio` PointTier or a list of `praatio` Points
+        tier (list[Point]|list[SequencePoint]|PointTier|Self): 
+            A list of SequencePoints, or another SequencePointTier
         entry_class (Type[SequencePoint]):
             A SequencePoint subclass
+
+    Examples:
+        ```{python}
+        from aligned_textgrid import SequencePoint, SequencePointTier
+
+        point_a = SequencePoint((0,"a"))
+        point_b = SequencePoint((1, "b"))
+
+        point_tier = SequencePointTier([point_a, point_b])
+
+        print(point_tier)
+        ```
+
+        ```{python}
+        print(point_tier.sequence_list)
+        ```
     
     Attributes:
         ...: 

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -290,14 +290,16 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
     # utilities
     def __init__(
         self, 
-        Interval: Interval = Interval(None, None, None)
+        interval: Interval|tuple= Interval(start=None, end=None, label = None),
+        *,
+        Interval = None
     ):
-        super().__init__()
-        if not Interval:
-            Interval = Interval(None, None, None)
-        self.start = Interval.start
-        self.end = Interval.end
-        self.label = Interval.label
+        if Interval:
+            interval = Interval
+
+        self.start = interval.start
+        self.end = interval.end
+        self.label = interval.label
         
         self.fol = None
         self.prev = None

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -344,6 +344,12 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
         rep_none = 3 - len(interval)
         interval += tuple([None]) * rep_none
 
+        if len(interval) > 3:
+            raise ValueError((
+                "The tuple or list to create a SequenceInterval should be no "
+                "more than 3 values long."
+            ))
+
         interval = praatio.utilities.constants.Interval(*interval)
 
         self.start = interval.start

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -303,6 +303,8 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
             End time of the interval
         label (Any):
             Label of the interval
+        duration (float):
+            The duration of the interval
         intier (SequenceTier):
             The sequence tier the current interval is within.
         tier_index (int):

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -347,7 +347,8 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
         if len(interval) > 3:
             raise ValueError((
                 "The tuple or list to create a SequenceInterval should be no "
-                "more than 3 values long."
+                "more than 3 values long. "
+                f"{len(interval)} were provided."
             ))
 
         interval = praatio.utilities.constants.Interval(*interval)

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -466,6 +466,10 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
     @property
     def duration(self) -> float:
         return self.end - self.start
+    
+    @property
+    def entry_class(self):
+        return self.__class__
       
     ## Fusion
     def fuse_rightwards(

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -10,6 +10,13 @@ from aligned_textgrid.mixins.within import WithinMixins
 from typing import Type, Any
 import numpy as np
 import warnings
+import sys
+from collections.abc import Sequence
+
+if sys.version_info >= (3,11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 class HierarchyMixins:
 

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -312,7 +312,7 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
         if Interval:
             interval = Interval
 
-        if isinstance(interval, self.__class__):
+        if isinstance(interval, SequenceInterval):
             interval = (
                 interval.start,
                 interval.end,

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -275,6 +275,27 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
             In this last case, only the `start`, `end` and `label` values from the original
             `SequenceInterval` are preserved in the new one. 
 
+    Examples:
+        A new `SequenceInterval` can be created from scratch by passing it a tuple
+        of a start time, end time, and a label
+        ```{python}
+        from aligned_textgrid import SequenceInterval
+
+        sample_interval = SequenceInterval((0, 1, "sample"))
+        print(sample_interval)
+        ```
+
+        You can pass a `SequenceInterval` to another
+        `SequenceInterval` or subclass (like [](`~aligned_textgrid.sequences.word_and_phone.Word`))
+        as well
+
+        ```{python}
+        from aligned_textgrid import Word
+
+        sample_word = Word(sample_interval)
+        print(sample_word)
+        ```
+
     Attributes:
         start (float):
             Start time of the interval
@@ -292,20 +313,20 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
             Instance of the previous interval. Is the same subclass as current instance.
         super_instance (SequenceInterval): 
             The instance of the superset. Cannot be the same subclass as the current instance.
-        subset_list (List[SequenceInterval]): 
+        subset_list (list[SequenceInterval]): 
             A list of subset instances. Cannot be the same subclass of the current instance.
         sub_starts (numpy.ndarray):
             A numpy array of start times for the subset list
         sub_ends (numpy.ndarray):
             A numpy array of end times for the subset list
-        sub_labels (List[Any]):
+        sub_labels (list[Any]):
             A list of labels from the subset list
     """    
 
     # utilities
     def __init__(
         self, 
-        interval: Interval|tuple= Interval(start=None, end=None, label = None),
+        interval: list|tuple|Interval|Self= (None, None, None),
         *,
         Interval = None
     ):
@@ -439,6 +460,10 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
             return lab_list
         else:
             return []
+        
+    @property
+    def duration(self) -> float:
+        return self.end - self.start
       
     ## Fusion
     def fuse_rightwards(

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -258,7 +258,13 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
     A class to describe an interval with precedence relationships and hierarchical relationships
 
     Args:
-        interval: A Praat textgrid Interval
+        interval (list|tuple|Interval|Self): 
+            A Praat textgrid Interval. This could one of: 
+            i) A list or tuple of start, end and label values (e.g. `[0, 1, "foo"]`); 
+            ii) A `praatio.utilities.constants.Interval`
+            iii) Another `SequenceInterval`. 
+            In this last case, only the `start`, `end` and `label` values from the original
+            `SequenceInterval` are preserved in the new one. 
 
     Attributes:
         start (float):

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -297,6 +297,17 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
         if Interval:
             interval = Interval
 
+        if isinstance(interval, self.__class__):
+            interval = (
+                interval.start,
+                interval.end,
+                interval.label
+            )
+        rep_none = 3 - len(interval)
+        interval += tuple([None]) * rep_none
+
+        interval = praatio.utilities.constants.Interval(*interval)
+
         self.start = interval.start
         self.end = interval.end
         self.label = interval.label

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -258,7 +258,7 @@ class SequenceInterval(InstanceMixins, InTierMixins, PrecedenceMixins, Hierarchy
     A class to describe an interval with precedence relationships and hierarchical relationships
 
     Args:
-        Interval: A Praat textgrid Interval
+        interval: A Praat textgrid Interval
 
     Attributes:
         start (float):

--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -3,7 +3,9 @@ Module includes the `SequenceInterval` base class as well as
 `Top` and `Bottom` classes.
 """
 
+import aligned_textgrid
 from praatio.utilities.constants import Interval
+import praatio
 from praatio.data_classes.interval_tier import IntervalTier
 from aligned_textgrid.mixins.mixins import InTierMixins, PrecedenceMixins
 from aligned_textgrid.mixins.within import WithinMixins

--- a/src/aligned_textgrid/sequences/word_and_phone.py
+++ b/src/aligned_textgrid/sequences/word_and_phone.py
@@ -1,29 +1,57 @@
 """
 Convenience classes for `Word` and `Phone` sequence intervals.
 """
-
+import aligned_textgrid
 from praatio.utilities.constants import Interval
 from praatio.data_classes.interval_tier import IntervalTier
 from aligned_textgrid.sequences.sequences import SequenceInterval, Top, Bottom
 import numpy as np
 
-
 class Phone(SequenceInterval):
     
-    """A Phone subclass of SequenceInterval
+    """A Phone subclass of [](`~aligned_textgrid.sequences.sequences.SequenceInterval`)
 
-    Has all the same methods and attributes as SequenceInterval in addition
-    to attributes described below. `superset_class` set to `Word`, 
-    and `subset_class` set to `Bottom`
+    Has all the same methods and attributes as [](`~aligned_textgrid.sequences.sequences.SequenceInterval`) 
+    in addition to attributes described below. `superset_class` set to 
+    [](`~aligned_textgrid.sequences.word_and_phone.Word`), 
+    and `subset_class` set to [](`~aligned_textgrid.sequences.sequences.Bottom`)
 
     Args:
-        Interval (Interval): A praatio Inteval
+        interval (list|tuple|Interval|SequenceInterval): 
+            A tuple or list of start, end and label, 
+            or another [](`~aligned_textgrid.sequences.sequences.SequenceInterval`)
+
+    Examples:
+        ```{python}
+        from aligned_textgrid import Word, Phone
+
+        DH = Phone((0, 1, "DH"))
+        AH0 = Phone((1, 2, "AH0"))
+
+        THE = Word((0, 2, "THE"))
+
+        DH.set_word(THE)
+        AH0.set_word(THE)
+
+        print(
+            (
+            f"The phone is {DH.label}. "
+            f"The next phone is {DH.fol.label}. "
+            f"It is in the word {DH.inword.label}."
+            )
+        )
+        ```
 
     Attributes:
         inword (Word): The word instance this phone appears in.
     """
-    def __init__(self, Interval = Interval(None, None, None)):
-         super().__init__(Interval)
+    def __init__(
+            self, 
+            interval: list|tuple|Interval|SequenceInterval= (None, None, None),
+            *,  
+            Interval = None
+            ):
+         super().__init__(interval, Interval=Interval)
 
     def set_word(
             self, 
@@ -41,14 +69,31 @@ class Phone(SequenceInterval):
         return self.super_instance
 
 class Word(SequenceInterval):
-    """A Word subclass of SequenceInterval
+    """A Word subclass of [](`~aligned_textgrid.sequences.sequences.SequenceInterval`)
 
-    Has all the same methods and attributes as SequenceInterval in addition
-    to attributes described below. `superset_class` set to `Top`, 
-    and `subset_class` set to `Phone`
+    Has all the same methods and attributes as [](`~aligned_textgrid.sequences.sequences.SequenceInterval`) 
+    in addition to attributes described below.  
+    `superset_class` set to [](`~aligned_textgrid.sequences.sequences.Top`), 
+    and `subset_class` set to [](`~aligned_textgrid.sequences.word_and_phone.Phone`)
 
     Args:
-        Interval (Interval): A praatio `Interval`
+        interval (list|tuple|Interval|SequenceInterval): 
+            A tuple or list of start, end and label, 
+            or another [](`~aligned_textgrid.sequences.sequences.SequenceInterval`)
+
+    Examples:
+        ```{python}
+        from aligned_textgrid import Word, Phone
+
+        DH = Phone((0, 1, "DH"))
+        AH0 = Phone((1, 2, "AH0"))
+
+        THE = Word((0, 2, "THE"))
+
+        THE.set_phones([DH, AH0])
+
+        print(THE.phones)
+        ```
     
     Attributes:
         phone_list (list[Phone]): A list of Phone objects
@@ -56,9 +101,12 @@ class Word(SequenceInterval):
     """
     def __init__(
             self, 
-            Interval = Interval(None, None, None)
+            interval: list|tuple|Interval|SequenceInterval= (None, None, None),
+            *,  
+            Interval = None
+
         ):
-        super().__init__(Interval)
+        super().__init__(interval, Interval=Interval)
     
     def set_phones(self, phone_list):
         """_Convenience function to set the phones_

--- a/tests/test_aligned_textgrid.py
+++ b/tests/test_aligned_textgrid.py
@@ -7,6 +7,7 @@ import numpy as np
 from praatio.utilities.constants import Interval
 from praatio.data_classes.interval_tier import IntervalTier
 from praatio.textgrid import openTextgrid
+from pathlib import Path
 
 class MyWord(SequenceInterval):
     def __init__(self, Interval = Interval(None, None, None)):
@@ -34,6 +35,31 @@ class TestReadFile:
             includeEmptyIntervals=True
         )
         atg = AlignedTextGrid(textgrid = tg)
+
+    def test_read_arg(self):
+        """
+        Test that the first unnamed arg can process
+        str, Path, and praatio.Textgrid classes correctly.
+        """
+        tg = openTextgrid(
+            fnFullPath="tests/test_data/KY25A_1.TextGrid",
+            includeEmptyIntervals=True
+        )        
+
+        atg1 = AlignedTextGrid(
+            "tests/test_data/KY25A_1.TextGrid",
+            entry_classes=[Word, Phone]
+        )
+        atg2 = AlignedTextGrid(
+            Path("tests/test_data/KY25A_1.TextGrid"),
+            entry_classes=[Word, Phone]
+        )
+        atg3 = AlignedTextGrid(
+           tg,
+            entry_classes=[Word, Phone]
+        )
+
+        assert len(atg1) == len(atg2) == len(atg3)
 
 class TestBasicRead:
 

--- a/tests/test_sequences/test_points.py
+++ b/tests/test_sequences/test_points.py
@@ -30,9 +30,15 @@ class TestPointCreation:
         seq_point = SequencePoint([0, "test"])
         assert isinstance(seq_point, SequencePoint)
 
+        with pytest.raises(ValueError):
+            SequencePoint([1,2,3])
+
     def test_tuple(self):
         seq_point = SequencePoint((0, "test"))
         assert isinstance(seq_point, SequencePoint)
+
+        with pytest.raises(ValueError):
+            assert SequencePoint((1,2,3))
 
     def test_self(self):
         class MyPoint(SequencePoint):

--- a/tests/test_sequences/test_points.py
+++ b/tests/test_sequences/test_points.py
@@ -24,6 +24,28 @@ class TestSequencePointDefault:
     def test_default_prev(self):
         assert self.seq_point.prev.label == "#"
 
+class TestPointCreation:
+
+    def test_list(self):
+        seq_point = SequencePoint([0, "test"])
+        assert isinstance(seq_point, SequencePoint)
+
+    def test_tuple(self):
+        seq_point = SequencePoint((0, "test"))
+        assert isinstance(seq_point, SequencePoint)
+
+    def test_self(self):
+        class MyPoint(SequencePoint):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+        
+        seq_point = SequencePoint((0, "test"))
+        new_point = MyPoint(seq_point)
+
+        assert isinstance(new_point, MyPoint)
+        assert new_point.time == seq_point.time
+        assert new_point.label == seq_point.label
+
 class TestPrecedence:
     seq_point_a = SequencePoint(Point(1, "a"))
     seq_point_b = SequencePoint(Point(2, "b"))

--- a/tests/test_sequences/test_sequences.py
+++ b/tests/test_sequences/test_sequences.py
@@ -18,7 +18,7 @@ class TestSequenceIntervalDefault:
             super().__init__(Interval = Interval)
 
     def test_default_class(self):
-        assert self.seq_int.__class__ is SequenceInterval
+        assert isinstance(self.seq_int, SequenceInterval)
     
     def test_default_super_class(self):
         assert self.seq_int.superset_class is Top
@@ -74,9 +74,37 @@ class TestSequenceIntervalDefault:
         local_sample = self.SampleClassI()
         assert local_sample.tier_index is None
 
-    def test_defaul_getby(self):
+    def test_default_getby(self):
         local_sample = self.SampleClassI()
         assert local_sample.get_tierwise(1) is None
+
+class TestSequenceIntervalCreation:
+
+    def test_empty(self):
+        test_int = SequenceInterval()
+
+    def test_list(self):
+        test_int = SequenceInterval([0, 1, "test"])
+        assert isinstance(test_int, SequenceInterval)
+
+    def test_tup(self):
+        test_int = SequenceInterval((0,1,"test"))
+        assert isinstance(test_int, SequenceInterval)
+    
+    def test_self(self):
+        class MyInterval(SequenceInterval):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+        
+        test_int = SequenceInterval((0, 1, "test"))
+        new_int = MyInterval(test_int)
+
+        assert isinstance(new_int, MyInterval)
+        assert new_int.start == test_int.start
+        assert new_int.end == test_int.end
+        assert new_int.label == test_int.label
+    
+
 
 class TestSuperSubClassSetting:
     class LocalClassA(SequenceInterval):

--- a/tests/test_sequences/test_sequences.py
+++ b/tests/test_sequences/test_sequences.py
@@ -87,9 +87,16 @@ class TestSequenceIntervalCreation:
         test_int = SequenceInterval([0, 1, "test"])
         assert isinstance(test_int, SequenceInterval)
 
+        with pytest.raises(ValueError):
+            SequenceInterval([1, 2, 3, 4])
+
+
     def test_tup(self):
         test_int = SequenceInterval((0,1,"test"))
         assert isinstance(test_int, SequenceInterval)
+
+        with pytest.raises(ValueError):
+            SequenceInterval((1, 2, 3, 4))
     
     def test_self(self):
         class MyInterval(SequenceInterval):

--- a/tests/test_tiers/test_PointTier.py
+++ b/tests/test_tiers/test_PointTier.py
@@ -11,25 +11,36 @@ class TestPointTierCreation:
     point_a = Point(1, "a")
     point_b = Point(2, "b")
 
+    point_a2 = SequencePoint((1, "a"))
+    point_b2 = SequencePoint((2, "b"))
+
     point_tier = PointTier(name = "test", entries = [point_a, point_b])
 
     seq_point_tier = SequencePointTier(point_tier)
+    seq_point_tier2 = SequencePointTier([point_a2, point_b2])
     seq_point_a = seq_point_tier[0]
+    seq_point_a2 = seq_point_tier2[0]
 
     def test_tier_name(self):
         assert self.seq_point_tier.name == "test"
+        assert self.seq_point_tier2.name == "SequencePoint"
 
     def test_tier_class(self):
         assert self.seq_point_tier.entry_class == SequencePoint
+        assert self.seq_point_tier2.entry_class == SequencePoint
     
     def test_tier_length(self):
         assert len(self.seq_point_tier) == 2
+        assert len(self.seq_point_tier2) == 2
     
     def test_indexing(self):
         assert self.seq_point_tier[0]
+        assert self.seq_point_tier2[0]
     
     def test_tier_contains(self):
         assert self.seq_point_a in self.seq_point_tier
+        assert self.seq_point_a2 in self.seq_point_tier2
+        assert not self.point_a2 in self.seq_point_tier2
     
     def test_intier(self):
         assert self.seq_point_a.intier is self.seq_point_tier
@@ -58,7 +69,35 @@ class TestPointTierCreation:
         out_tier = self.seq_point_tier.return_tier()
         assert isinstance(out_tier, PointTier)
 
+class TestClassSetting:
+
+    class MyPointA(SequencePoint):
+        def __init__(self, *args):
+            super().__init__(*args)
+
+    class MyPointB(SequencePoint):
+        def __init__(self, *args):
+            super().__init__(*args)
+
+    def test_class_from_point(self):
+        point_a = self.MyPointA((1, "a"))
+        point_b = self.MyPointA((2, "b"))
+
+        point_tier = SequencePointTier([point_a, point_b])
+        assert issubclass(point_tier.entry_class, self.MyPointA)    
+
+    def test_override_class(self):
+        point_a = self.MyPointA((1, "a"))
+        point_b = self.MyPointA((2, "b"))
+
+        point_tier = SequencePointTier([point_a, point_b], entry_class=self.MyPointB)
+
+        assert issubclass(point_tier.entry_class, self.MyPointB)
+        assert not issubclass(point_tier.entry_class, self.MyPointA)
+
+
 class TestPointPrecedence:
+
     def test_first_last(self):
         point_a = Point(1, "a")
         point_b = Point(2, "b")

--- a/tests/test_tiers/test_SequenceTier.py
+++ b/tests/test_tiers/test_SequenceTier.py
@@ -1,6 +1,7 @@
 import pytest
 from aligned_textgrid.sequences.sequences import *
 from aligned_textgrid.sequences.tiers import *
+from aligned_textgrid import Word, Phone
 import numpy as np
 from praatio.utilities.constants import Interval
 from praatio.data_classes.interval_tier import IntervalTier
@@ -49,6 +50,26 @@ class TestSequenceTierDefault:
     def test_default_getitme(self):
         with pytest.raises(IndexError):
             _ = self.default_tier[0]
+
+class TestTierMaking:
+
+    def test_class_setting(self):
+        the = Word((0,1,"the"))
+        dog = Word((1,2,"dog"))
+        tier = SequenceTier([the, dog])
+        assert issubclass(tier.entry_class, Word)
+        assert all([isinstance(x, Word) for x in tier])
+
+        tier2 = SequenceTier([the, dog], entry_class=Phone)
+        assert issubclass(tier2.entry_class, Phone)
+        assert all([isinstance(x, Phone) for x in tier2])
+
+        tier3 = SequenceTier(tier2, entry_class=Word)
+        assert issubclass(tier3.entry_class, Word)
+        assert all([isinstance(x, Word) for x in tier3])
+
+    
+
 
 class TestReadTier:
     read_tg = openTextgrid(


### PR DESCRIPTION
This PR flexibilizes the creation of aligned_textgrid objects in a number of ways.

## `AlignedTextGrid`

The first position argument to `AlignedTextGrid()` can now be one of

- A `str` representing a path to a textgrid.
- A `pathlib:Path` to a textgrid
- A `praatio.textgrid.Textgrid`

The original `textgrid_path` argument can still be utilized without breaking previous code.


## `SequenceInterval` and `SequencePoint`

The first argument to both `SequenceInterval` and `SequencePoint` can now also be a list or tuple of the relevant time and label information. e.g.

```{python}
seq_int = SequenceInterval((0, 1, "a"))
seq_point = SequencePoint((0, "a"))
```

## `SequenceTier` and `SequencePointTier`

These can now also be passed lists of `SequenceInterval` and `SequencePoint`, as appropriate, or another tier of its own class.
