### PR TITLE
AlignedTextGrid creation flexibilization

### DIFF
--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -12,7 +12,7 @@ from aligned_textgrid.sequences.tiers import SequenceTier, TierGroup
 from aligned_textgrid.points.tiers import SequencePointTier, PointsGroup
 from aligned_textgrid.mixins.within import WithinMixins
 from aligned_textgrid.custom_classes import custom_classes, clone_class, get_class_hierarchy
-from typing import Type, Sequence, Literal
+from typing import Type, Literal
 from copy import copy
 import numpy as np
 from collections.abc import Sequence

--- a/src/aligned_textgrid/mixins/within.py
+++ b/src/aligned_textgrid/mixins/within.py
@@ -1,4 +1,5 @@
-from typing import TypeVar, Sequence, TYPE_CHECKING
+from collections.abc import Sequence
+from typing import TypeVar, TYPE_CHECKING
 if TYPE_CHECKING:
     from aligned_textgrid import SequenceInterval, \
         SequenceTier,\

--- a/src/aligned_textgrid/points/tiers.py
+++ b/src/aligned_textgrid/points/tiers.py
@@ -232,7 +232,7 @@ class PointsGroup(Sequence, TierGroupMixins, WithinMixins):
     [](`~aligned_textgrid.mixins.within.WithinMixins`)
 
     Args:
-        tiers (list[SequencePointTier]: 
+        tiers (list[SequencePointTier]|PointsGroup): 
             A list of SequencePointTiers
     
     Attributes:
@@ -240,8 +240,10 @@ class PointsGroup(Sequence, TierGroupMixins, WithinMixins):
     """    
     def __init__(
             self,
-            tiers: list[SequencePointTier] = [SequencePointTier()]
+            tiers: list[SequencePointTier]|Self = [SequencePointTier()]
     ):
+        if isinstance(tiers, PointsGroup):
+            tiers = [tier for tier in tiers]
         self.tier_list = tiers
         self.contains = self.tier_list
         self._set_tier_names()

--- a/tests/test_add_append.py
+++ b/tests/test_add_append.py
@@ -400,6 +400,73 @@ class TestTierGroups:
 
         assert word1.fol is word2
 
+class TestATG:
+
+    def test_atg_append(self):
+        tg1 = TierGroup()
+        tg2 = TierGroup()
+        pg1 = PointsGroup()
+        atg = AlignedTextGrid()
+
+        atg.append(tg1)
+        atg.append(tg2)
+        atg.append(pg1)
+
+        assert tg1 in atg
+        assert tg2 in atg
+        assert pg1 in atg
+
+        assert tg1 in atg.contains
+        assert tg2 in atg.contains
+        assert pg1 in atg.contains
+
+        assert tg1.within is atg
+        assert tg2.within is atg
+        assert pg1.within is atg
+
+    def test_clone_on_append(self):
+        MyWord, = custom_classes(["MyWord"])
+        tgr = TierGroup([
+            SequenceTier([
+                MyWord((0,10,"test"))
+            ])
+        ])
+
+        atg = AlignedTextGrid()
+        atg.append(tgr)
+
+        assert tgr in atg
+
+        assert not tgr.entry_classes[0] is MyWord
+        assert tgr.entry_classes[0].__name__ == "MyWord"
+        assert isinstance(tgr.MyWord.first, MyWord)
+
+    def test_clone_reuse(self):
+        MyWord, = custom_classes(["MyWord"])
+        tgr1 = TierGroup([
+            SequenceTier([
+                MyWord((0,10,"test"))
+            ])
+        ])
+
+        tgr2 = TierGroup([
+            SequenceTier([
+                MyWord((0,10,"test"))
+            ])
+        ])
+
+        atg = AlignedTextGrid()
+
+        assert tgr1.entry_classes[0] is MyWord
+        assert tgr2.entry_classes[0] is MyWord
+
+        atg.append(tgr1)
+        atg.append(tgr2)
+
+        assert not tgr1.entry_classes[0] is MyWord
+        assert not tgr2.entry_classes[0] is MyWord
+
+        assert tgr1.entry_classes[0] is tgr2.entry_classes[0]
 
 class TestCleanups:
     def test_sequence_cleanup(self):

--- a/tests/test_aligned_textgrid.py
+++ b/tests/test_aligned_textgrid.py
@@ -119,6 +119,45 @@ class TestMultiRead:
         assert len(atg_multi[0]) == 2 and len(atg_multi[2]) == 2
         assert len(atg_multi[1]) == 1 and len(atg_multi[3]) == 1
 
+class TestManualCreation:
+    def test_manual_creation(self):
+        tg1 = TierGroup()
+        tg2 = TierGroup()
+
+        atg = AlignedTextGrid([tg1, tg2])
+
+        assert tg1 in atg
+        assert tg2 in atg
+
+        assert tg1 in atg.contains
+        assert tg2 in atg.contains
+
+        assert tg1.within is atg
+        assert tg2.within is atg
+
+    def test_append(self):
+        atg = AlignedTextGrid(
+            "tests/test_data/KY25A_1.TextGrid", 
+            entry_classes=[MyWord, MyPhone]
+        )
+
+        orig_tgr = atg[0]
+        word_tier = orig_tgr.MyWord
+        phone_tier = orig_tgr.MyPhone
+
+        empty_tgr = TierGroup()
+
+        atg.append(empty_tgr)
+
+        assert orig_tgr in atg
+        assert empty_tgr in atg
+
+        assert orig_tgr.within is atg
+        assert empty_tgr.within is atg
+
+        assert atg[0].MyWord is word_tier
+        assert atg[0].MyPhone is phone_tier
+
 class TestClassSetting:
     atg1 = AlignedTextGrid(
         textgrid_path="tests/test_data/KY25A_1.TextGrid", 


### PR DESCRIPTION
A new `AlignedTextGrid` can now be created with a list of TierGroups

```python
atg = AlignedTextGrid([TierGroup(), TierGroup()])
```

The way class-cloning is done has also been streamlined so that `atg.append()` will appropriately clone the classes of a tier group, re-using already cloned classes if they exist.