### PR TITLE
pass args and kwargs to *ward methods

### DIFF
--- a/src/aligned_textgrid/sequences/sequences.py
+++ b/src/aligned_textgrid/sequences/sequences.py
@@ -629,12 +629,14 @@ class SequenceInterval(SequenceBaseClass, InstanceMixins, InTierMixins, Preceden
                     fuser.super_instance.subset_list.remove(fusee)                    
         else:
             raise Exception("Cannot fuse leftwards at right edge")
+        
+        return self
     
-    def fuse_rightward(self)->None:
-        self.fuse_rightwards()
+    def fuse_rightward(self, *args, **kwargs)->None:
+        self.fuse_rightwards(*args, **kwargs)
 
-    def fuse_leftward(self)->None:
-        self.fuse_leftwards()        
+    def fuse_leftward(self, *args, **kwargs)->None:
+        self.fuse_leftwards(*args, **kwargs)        
 
     ## Extensions and Saving
     def set_feature(

--- a/tests/test_sequences/test_sequences.py
+++ b/tests/test_sequences/test_sequences.py
@@ -586,7 +586,32 @@ class TestFusion:
             ):
             super().__init__(Interval)
 
-    Lower.set_superset_class(Upper)                        
+    Lower.set_superset_class(Upper)
+
+    def test_rightward_alias(self):
+        fuser = self.SampleClass(Interval(0,1,"one"))
+        fusee = self.SampleClass(Interval(1, 2, "two"))
+        fuser.set_fol(fusee)
+
+        try:
+            fuser.fuse_rightward(label_fun = lambda x, y: x + "." + y)
+        except:
+            assert False
+
+        assert fuser.label == "one.two"
+
+    def test_leftward_alias(self):
+        fusee = self.SampleClass(Interval(0,1,"one"))
+        fuser = self.SampleClass(Interval(1, 2, "two"))
+        fuser.set_prev(fusee)
+
+        try:
+            fuser.fuse_leftward(label_fun = lambda x, y: x + "." + y)
+        except:
+            assert False
+
+        assert fuser.label == "one.two"        
+
 
     def test_rightwards_simple(self):
         fuser = self.SampleClass(Interval(0,1,"one"))


### PR DESCRIPTION
Convenience `fuse_rightward()` and `fuse_leftward()` methods didn't pass args or kwargs