### PR TITLE
fix to saving custom built textgrids

### DIFF
--- a/src/aligned_textgrid/aligned_textgrid.py
+++ b/src/aligned_textgrid/aligned_textgrid.py
@@ -794,9 +794,16 @@ class AlignedTextGrid(Sequence, WithinMixins):
                 A `praatio` `Textgrid`
         """
         out_tg = Textgrid()
+        tier_names = []
+        dup_idx = 0
         for group in self.tier_groups:
             for tier in group:
-                out_tg.addTier(tier = tier.return_tier())
+                name = tier.name
+                if name in tier_names:
+                    name = f"{name}_{dup_idx}"
+                    dup_idx += 1 
+                tier_names += [name]
+                out_tg.addTier(tier = tier.return_tier(name))
         return out_tg
 
     def save_textgrid(

--- a/src/aligned_textgrid/points/tiers.py
+++ b/src/aligned_textgrid/points/tiers.py
@@ -202,14 +202,16 @@ class SequencePointTier(Sequence, TierMixins, WithinMixins):
         out_idx = self.get_nearest_point_index(time)
         return self.sequence_list[out_idx]
 
-    def return_tier(self) -> PointTier:
+    def return_tier(self, name:str|None = None) -> PointTier:
         """Returns SequencePointTier as a `praatio` PointTier
 
         Returns:
             (PointTier): A `praatio` point tier
         """
+        if name is None:
+            name = self.name
         all_points = [entry.return_point() for entry in self.sequence_list]
-        point_tier = PointTier(name = self.name, entries=all_points)
+        point_tier = PointTier(name = name, entries=all_points)
         return(point_tier)
     
     def save_as_tg(

--- a/src/aligned_textgrid/sequences/tiers.py
+++ b/src/aligned_textgrid/sequences/tiers.py
@@ -307,7 +307,7 @@ class SequenceTier(Sequence, TierMixins, WithinMixins):
         else:
             return None
     
-    def return_tier(self) -> IntervalTier:
+    def return_tier(self, name:str|None = None) -> IntervalTier:
         """Returns a `praatio` interval tier
 
         Returns:
@@ -315,8 +315,11 @@ class SequenceTier(Sequence, TierMixins, WithinMixins):
                 A `praatio` interval tier. Useful for saving results
                 back as a Praat TextGrid.
         """
+        
+        if name is None:
+            name = self.name
         all_intervals = [entry.return_interval() for entry in self.sequence_list]
-        interval_tier = IntervalTier(name = self.name, entries = all_intervals)
+        interval_tier = IntervalTier(name = name, entries = all_intervals)
         return interval_tier
 
     

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -5,7 +5,6 @@ from aligned_textgrid.polar.polar_grid import PolarGrid
 from aligned_textgrid.outputs.to_dataframe import to_df
 from functools import reduce
 import cloudpickle
-import tempfile
 class TestDataframes:
 
     atg = AlignedTextGrid(
@@ -97,25 +96,7 @@ class TestCustomWrite:
         speaker1[0].append(the_dog)
         speaker2[0].append(the_cat)
         atg = AlignedTextGrid([speaker1, speaker2])
-        tmp_file = tempfile.TemporaryFile()
-        atg.save_textgrid(tmp_file.name)
-
-
-        # for phone in [DH, AH0]:
-        #     the.append(phone)
-
-        # for phone in [D, AO1, G]:
-        #     dog.append(phone)        
-
-        # tier_group = TierGroup([
-        #     SequenceTier(entry_class=Word),
-        #     SequenceTier(entry_class=Phone)
-        # ])
-
-        # tier_group.Word.append(the)
-        # tier_group.Word.append(dog)
-
-        # atg = AlignedTextGrid([tier_group])
+        assert atg.return_textgrid()
 
         
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,10 +1,11 @@
-from aligned_textgrid import AlignedTextGrid, Word, Phone
+from aligned_textgrid import AlignedTextGrid, Word, Phone, SequenceTier, TierGroup, custom_classes
 from aligned_textgrid.polar.polar_classes import PrStr, ToBI, \
     TurningPoints, Ranges, Levels, Misc
 from aligned_textgrid.polar.polar_grid import PolarGrid
 from aligned_textgrid.outputs.to_dataframe import to_df
 from functools import reduce
 import cloudpickle
+import tempfile
 class TestDataframes:
 
     atg = AlignedTextGrid(
@@ -83,3 +84,38 @@ class TestPickle:
     )
     def test_pickling(self):
         assert cloudpickle.loads(cloudpickle.dumps(self.atg))
+
+class TestCustomWrite:
+
+    def test_write(self):
+        Transcript, = custom_classes(["Transcript"])
+        the_dog = Transcript((0, 10, "the dog"))
+        the_cat = Transcript((10, 25, "dog cat"))
+        speaker1 = TierGroup([SequenceTier(entry_class=Transcript)])
+        speaker2 = TierGroup([SequenceTier(entry_class=Transcript)])
+
+        speaker1[0].append(the_dog)
+        speaker2[0].append(the_cat)
+        atg = AlignedTextGrid([speaker1, speaker2])
+        tmp_file = tempfile.TemporaryFile()
+        atg.save_textgrid(tmp_file.name)
+
+
+        # for phone in [DH, AH0]:
+        #     the.append(phone)
+
+        # for phone in [D, AO1, G]:
+        #     dog.append(phone)        
+
+        # tier_group = TierGroup([
+        #     SequenceTier(entry_class=Word),
+        #     SequenceTier(entry_class=Phone)
+        # ])
+
+        # tier_group.Word.append(the)
+        # tier_group.Word.append(dog)
+
+        # atg = AlignedTextGrid([tier_group])
+
+        
+


### PR DESCRIPTION
Custom built textgrids will now be sure to unique-ify tier names if there are duplicates.